### PR TITLE
Fix: Mounting volume causing import errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     build: ./react_frontend
     container_name: react-frontend
     volumes:
-      - ./react_frontend:/app
+      - ./react_frontend/src:/app/src
     ports:
       - "3000:3000"
     environment:


### PR DESCRIPTION
Previously node_modules would be mounted leading to import errors. Now only src is mounted to allow for hot reload.